### PR TITLE
Fixed EntityIndexingStrategy when non entity is given.

### DIFF
--- a/lib/FSi/Component/DataGrid/Data/EntityIndexingStrategy.php
+++ b/lib/FSi/Component/DataGrid/Data/EntityIndexingStrategy.php
@@ -48,6 +48,9 @@ class EntityIndexingStrategy implements IndexingStrategyInterface
 
         $class = get_class($object);
         $em = $this->registry->getManagerForClass($class);
+        if (!$em) {
+            return null;
+        }
         $metadataFactory = $em->getMetadataFactory();
         $metadata = $metadataFactory->getMetadataFor($class);
 

--- a/tests/FSi/Component/DataGrid/Tests/Data/EntityIndexingStrategyTest.php
+++ b/tests/FSi/Component/DataGrid/Tests/Data/EntityIndexingStrategyTest.php
@@ -143,4 +143,11 @@ class EntityIndexingStrategyTest extends \PHPUnit_Framework_TestCase
             $this->assertSame(array('id' => '1', 'name' => 'Foo' ), $strategy->revertIndex($index, 'Entity'));
         }
     }
+
+    public function testGetIndexForNonEntities()
+    {
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $strategy = new EntityIndexingStrategy($registry);
+        $this->assertSame(null, $strategy->getIndex(new \stdClass(), $this->dataMapper));
+    }
 }


### PR DESCRIPTION
EntityIndexingStrategy throwed an Exception when non entity was given. 

```
$class = get_class($object);
$em = $this->registry->getManagerForClass($class);
```

`$em` is not set, so exception is throwed.

Because of that it was impossible to use datagrid with arbitrary objects (like anonymous objects fetched by PDO).
