### PR TITLE
Simplified tests execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
 before_script:
     - composer install --dev
 
-script: phpunit -c tests
+script: phpunit

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ To run tests for DataGrid you should install dev packages and run tests with com
 
 ```
     $ php composer.phar install --dev
-    $ phpunit -c tests
+    $ phpunit
 ```
 
 ## Extensions ##

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,11 +8,11 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
     <testsuites>
         <testsuite name="FSi DataGrid Component">
-            <directory>./FSi/Component/DataGrid/Tests</directory>
+            <directory>tests/FSi/Component/DataGrid/Tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
It allows to execute tests without any additional parameter, just `phpunit` in console. 

@chives what do you think ?
