### PR TITLE
Get data from propert parameter bag in bind request event listener

### DIFF
--- a/lib/FSi/Component/DataGrid/Extension/Symfony/EventSubscriber/BindRequest.php
+++ b/lib/FSi/Component/DataGrid/Extension/Symfony/EventSubscriber/BindRequest.php
@@ -46,8 +46,10 @@ class BindRequest implements EventSubscriberInterface
             case 'PUT':
             case 'DELETE':
             case 'PATCH':
+                $data = $request->request->get($name, $default);
+                break;
             case 'GET':
-                $data = $request->get($name, $default);
+                $data = $request->query->get($name, $default);
                 break;
 
             default:

--- a/tests/FSi/Component/DataGrid/Tests/Extension/Symfony/EventSubscriber/BindRequestTest.php
+++ b/tests/FSi/Component/DataGrid/Tests/Extension/Symfony/EventSubscriber/BindRequestTest.php
@@ -35,10 +35,13 @@ class BindRequestTest extends \PHPUnit_Framework_TestCase
              ->method('getMethod')
              ->will($this->returnValue('POST'));
 
-        $request->expects($this->once())
+        $requestBag = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $requestBag->expects($this->once())
             ->method('get')
             ->with('grid', array())
             ->will($this->returnValue(array('foo' => 'bar')));
+
+        $request->request = $requestBag;
 
         $grid = $this->getMock('FSi\Component\DataGrid\DataGridInterface');
         $grid->expects($this->once())
@@ -74,10 +77,13 @@ class BindRequestTest extends \PHPUnit_Framework_TestCase
              ->method('getMethod')
              ->will($this->returnValue('GET'));
 
-        $request->expects($this->once())
+        $queryBag = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $queryBag->expects($this->once())
             ->method('get')
             ->with('grid', array())
             ->will($this->returnValue(array('foo' => 'bar')));
+
+        $request->query = $queryBag;
 
         $grid = $this->getMock('FSi\Component\DataGrid\DataGridInterface');
         $grid->expects($this->once())


### PR DESCRIPTION
Without this PR "edit at list" feature cannot work properly in `fsi/admin-bundle`
