### PR TITLE
Added getActionOptionsResolver() to both Action column types

### DIFF
--- a/lib/FSi/Component/DataGrid/Extension/Core/ColumnType/Action.php
+++ b/lib/FSi/Component/DataGrid/Extension/Core/ColumnType/Action.php
@@ -124,4 +124,12 @@ class Action extends ColumnAbstractType
             )
         ));
     }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    public function getActionOptionsResolver()
+    {
+        return $this->actionOptionsResolver;
+    }
 }

--- a/lib/FSi/Component/DataGrid/Extension/Symfony/ColumnType/Action.php
+++ b/lib/FSi/Component/DataGrid/Extension/Symfony/ColumnType/Action.php
@@ -153,4 +153,12 @@ class Action extends ColumnAbstractType
             'route_name',
         ));
     }
+
+    /**
+     * @return \Symfony\Component\OptionsResolver\OptionsResolver
+     */
+    public function getActionOptionsResolver()
+    {
+        return $this->actionOptionsResolver;
+    }
 }


### PR DESCRIPTION
This addition will allow column type extensions (of action column type) to add and/or modify not only column options but also single action options.

``` php
class SomeActionExtension extends ColumnAbstractTypeExtension
{
    public function getExtendedColumnType()
    {
        return 'action';
    }

    public function initOptions(ColumnTypeInterface $column)
    {
         $column->getActionOptionsResolver()->setDefaults(array('custom_action_option' => false));
         $column->getActionOptionsResolver()->setAllowedTypes(array('custom_action_option' => 'bool'));
    }

    public function filterValue(ColumnTypeInterface $column, $value)
    {
        $actions = $column->getOption('actions');
        foreach ($actions as $name => $options) {
            $options = $column->getActionOptionsResolver()->resolve((array) $options);
            // do something with $options['custom_action_option'] for example modify $value or other action options
        }

        return parent::filterValue($column, $value);
    }
}
```
