### PR TITLE
Fix format_decimals on Symfony 3+

### DIFF
--- a/lib/Extension/Core/ColumnType/Number.php
+++ b/lib/Extension/Core/ColumnType/Number.php
@@ -45,7 +45,7 @@ class Number extends ColumnAbstractType
             }
 
             if ($format) {
-                $val = number_format($val, $format_decimals, $format_dec_point, $format_thousands_sep);
+                $val = number_format((float) $val, $format_decimals, $format_dec_point, $format_thousands_sep);
             }
         }
 


### PR DESCRIPTION
Symfony 3+ passes string into $value parameter of filterValue method. If we don't specify 'round_mode', number_format throws 'TypeError'