### PR TITLE
Enhance expected exception tests

### DIFF
--- a/tests/DataGridFactoryTest.php
+++ b/tests/DataGridFactoryTest.php
@@ -44,6 +44,7 @@ class DataGridFactoryTest extends TestCase
         $this->assertSame('grid',$grid->getName());
 
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('Datagrid name "grid" is not uniqe, it was used before to create datagrid');
         $this->factory->createDataGrid('grid');
     }
 
@@ -58,6 +59,7 @@ class DataGridFactoryTest extends TestCase
         $this->assertInstanceOf(FooType::class, $this->factory->getColumnType('foo'));
 
         $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('There is no column with type "bar" registered in factory.');
         $this->factory->getColumnType('bar');
     }
 

--- a/tests/DataGridTest.php
+++ b/tests/DataGridTest.php
@@ -113,6 +113,7 @@ class DataGridTest extends TestCase
         $this->assertCount(0, $this->datagrid->getColumns());
 
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column "bar" does not exist in data grid.');
         $this->datagrid->getColumn('bar');
     }
 

--- a/tests/DataMapper/ChainMapperTest.php
+++ b/tests/DataMapper/ChainMapperTest.php
@@ -22,6 +22,7 @@ class ChainMapperTest extends TestCase
     public function testMappersInChainWithInvalidMappers()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Mapper needs to implement "%s"', DataMapperInterface::class));
         new ChainMapper([
             'foo',
             'bar'
@@ -31,6 +32,7 @@ class ChainMapperTest extends TestCase
     public function testMappersInChainWithEmptyMappersArray()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Mapper needs to implement "%s"', DataMapperInterface::class));
         new ChainMapper([
             'foo',
             'bar'

--- a/tests/DataMapper/ReflectionMapperTest.php
+++ b/tests/DataMapper/ReflectionMapperTest.php
@@ -34,6 +34,7 @@ class ReflectionMapperTest extends TestCase
         $entity->setSurname('foosurname');
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Method "getSurname()" is not public in class "%s"', EntityMapper::class));
         $mapper->getData('surname', $entity);
     }
 
@@ -53,6 +54,7 @@ class ReflectionMapperTest extends TestCase
         $entity->setPrivateCollection('collection');
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Method "hasPrivateCollection()" is not public in class "%s"', EntityMapper::class));
         $mapper->getData('private_collection', $entity);
     }
 
@@ -72,6 +74,7 @@ class ReflectionMapperTest extends TestCase
         $entity->setProtectedReady(true);
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Method "isProtectedReady()" is not public in class "%s"', EntityMapper::class));
         $mapper->getData('protected_ready', $entity);
     }
 
@@ -91,6 +94,7 @@ class ReflectionMapperTest extends TestCase
         $entity->setPrivateId('bar');
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Property "private_id" is not public in class "%s"', EntityMapper::class));
         $mapper->getData('private_id', $entity);
     }
 
@@ -109,6 +113,7 @@ class ReflectionMapperTest extends TestCase
         $entity = new EntityMapper();
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Method "setProtectedName()" is not public in class "%s"', EntityMapper::class));
         $mapper->setData('protected_name', $entity, 'fooname');
     }
 
@@ -127,6 +132,7 @@ class ReflectionMapperTest extends TestCase
         $entity = new EntityMapper();
 
         $this->expectException(DataMappingException::class);
+        $this->expectExceptionMessage(sprintf('Method "addProtectedTag()" is not public in class "%s"', EntityMapper::class));
         $mapper->setData('protected_tag', $entity, 'bar');
     }
 }

--- a/tests/Extension/Core/ColumnType/ActionTest.php
+++ b/tests/Extension/Core/ColumnType/ActionTest.php
@@ -24,7 +24,7 @@ class ActionTest extends TestCase
      */
     private $column;
 
-    public function setUp()
+    protected function setUp()
     {
         $column = new Action();
         $column->setName('action');
@@ -39,6 +39,7 @@ class ActionTest extends TestCase
     public function testFilterValueEmptyActionsOptionType()
     {
         $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage('The option "actions" with value "boo" is expected to be of type "array", but is of type "string".');
         $this->column->setOption('actions', 'boo');
         $this->column->filterValue([]);
     }

--- a/tests/Extension/Core/ColumnType/BooleanTest.php
+++ b/tests/Extension/Core/ColumnType/BooleanTest.php
@@ -21,7 +21,7 @@ class BooleanTest extends TestCase
      */
     private $column;
 
-    public function setUp()
+    protected function setUp()
     {
         $column = new Boolean();
         $column->setName('available');

--- a/tests/Extension/Core/ColumnType/DateTimeTest.php
+++ b/tests/Extension/Core/ColumnType/DateTimeTest.php
@@ -23,7 +23,7 @@ class DateTimeTest extends TestCase
      */
     private $column;
 
-    public function setUp()
+    protected function setUp()
     {
         $column = new DateTime();
         $column->setName('datetime');
@@ -180,6 +180,7 @@ class DateTimeTest extends TestCase
         );
 
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value in column "datetime" should be timestamp but "object" type was detected. Maybe you should consider using different "input" opition value?');
         $this->column->filterValue($brokenValue);
     }
 
@@ -193,6 +194,7 @@ class DateTimeTest extends TestCase
         $this->column->setOption('input_type', 'string');
 
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('"mapping_fields_format" option is missing. Example: "mapping_fields_format" => "Y-m-d H:i:s"');
         $this->column->filterValue($value);
     }
 
@@ -221,6 +223,7 @@ class DateTimeTest extends TestCase
         );
 
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('Value in field "datetime" is not a valid string.');
         $this->column->filterValue($brokenValue);
     }
 
@@ -236,6 +239,7 @@ class DateTimeTest extends TestCase
 
         $this->column->setOption('input_type', 'array');
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('"input_field_format" option is missing. Example: "input_field_format" => array("mapping_field_name" => array("input" => "datetime"))');
         $this->column->filterValue($value);
     }
 
@@ -256,6 +260,7 @@ class DateTimeTest extends TestCase
         $this->column->setOption('input_type', 'array');
 
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('"input_field_format" option is missing. Example: "input_field_format" => array("mapping_field_name" => array("input" => "datetime"))');
         $this->column->filterValue($value);
     }
 
@@ -277,6 +282,7 @@ class DateTimeTest extends TestCase
         ]);
 
         $this->expectException(DataGridColumnException::class);
+        $this->expectExceptionMessage('When using input type "string", "mapping_fields_format" option must be an string that contains valid data format');
         $this->column->filterValue($value);
     }
 

--- a/tests/Extension/Core/ColumnType/MoneyTest.php
+++ b/tests/Extension/Core/ColumnType/MoneyTest.php
@@ -22,7 +22,7 @@ class MoneyTest extends TestCase
      */
     private $column;
 
-    public function setUp()
+    protected function setUp()
     {
         $column = new Money();
         $column->setName('money');

--- a/tests/Extension/Core/ColumnType/NumberTest.php
+++ b/tests/Extension/Core/ColumnType/NumberTest.php
@@ -22,7 +22,7 @@ class NumberTest extends TestCase
      */
     private $column;
 
-    public function setUp()
+    protected function setUp()
     {
         $column = new Number();
         $column->setName('number');

--- a/tests/Extension/Core/ColumnTypeExtension/ValueFormatColumnOptionsExtensionTest.php
+++ b/tests/Extension/Core/ColumnTypeExtension/ValueFormatColumnOptionsExtensionTest.php
@@ -151,6 +151,7 @@ class ValueFormatColumnOptionsExtensionTest extends TestCase
             ->will($this->returnValue(['foo', 'bar']));
 
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one of "value_format" or "value_glue" option is missing in column: "".');
         $extension->buildCellView($column, $view);
     }
 
@@ -492,6 +493,7 @@ class ValueFormatColumnOptionsExtensionTest extends TestCase
             }));
 
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mapping field "fo" doesn\'t exist in column: "".');
         $extension->buildCellView($column, $view);
     }
 

--- a/tests/Extension/Doctrine/ColumnTypeExtension/ValueFormatColumnOptionsExtensionTest.php
+++ b/tests/Extension/Doctrine/ColumnTypeExtension/ValueFormatColumnOptionsExtensionTest.php
@@ -235,6 +235,7 @@ class ValueFormatColumnOptionsExtensionTest extends TestCase
             ->will($this->returnValue(['id2' => 'no','name' => 'no']));
 
         $this->expectException(DataGridException::class);
+        $this->expectExceptionMessage('Not found key "id" in empty_value array');
         $extension->buildCellView($column, $view);
     }
 

--- a/tests/Extension/Gedmo/ColumnType/Tree/TreeTypeTest.php
+++ b/tests/Extension/Gedmo/ColumnType/Tree/TreeTypeTest.php
@@ -40,7 +40,8 @@ class TreeTypeTest extends TestCase
 
         $object = 'This is string, not object';
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column "gedmo_tree" must read value from object.');
         $column->getValue($object);
     }
 


### PR DESCRIPTION
# Changed log
- Add the `expectExceptionMessage` method to assert that the expected exception message is same as result.
- Using the `::class` magic call to replace the class string.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method should be `protected`, not `public`.